### PR TITLE
Prevent hanging install_spinnaker.sh script durring getting terraform version on Mac OS

### DIFF
--- a/install_spinnaker.sh
+++ b/install_spinnaker.sh
@@ -114,7 +114,7 @@ done
 ./support/check_python_prereqs.py $CLOUD_PROVIDER
 RETVAL=$?
 
-TF_VERSION=`terraform -version | head -1 | sed -e 's/.*v//'`
+TF_VERSION=`terraform -version | sed -e 's/.*v//' | head -1`
 TF_FORMATTED_VERSION=`echo $TF_VERSION | sed -e 's/.*v//' -e 's/\.//' -e 's/\.//'`
 
 REQD_TF_VERSION='0.6.9'


### PR DESCRIPTION
Hey, @kenzanlabs.

I want to thank you for well done project. It helped me a lot.

Still I had an issue with running `install_spinnaker.sh` script on Mac OS (OS X El Capitan, v10.11.3). The issue was that this script hanged its execution on checking dependencies stage. After I found out that executions hangs on this command `terraform -version | head -1`. Seems like pipe is not closed. I tested it on another Mac and got the same problem.

The solution was to change order of `head` and `sed` commands. This worked both on Mac OS and Ubuntu.
