### PR TITLE
Changed template_file resource to a data source. install_spinnaker.sh…

### DIFF
--- a/aws/instances.tf
+++ b/aws/instances.tf
@@ -1,7 +1,7 @@
 
 /* bastion instance */
 resource "aws_instance" "bastion" {
-  ami = "${lookup(var.aws_ubuntu_amis, format(\"%s-%s-%s-%s-%s\", var.region, var.ubuntu_distribution, var.ubuntu_architecture, var.ubuntu_virttype, var.ubuntu_storagetype))}"
+  ami = "${lookup(var.aws_ubuntu_amis, format("%s-%s-%s-%s-%s", var.region, var.ubuntu_distribution, var.ubuntu_architecture, var.ubuntu_virttype, var.ubuntu_storagetype))}"
   instance_type = "${var.bastion_instance_type}"
   subnet_id = "${aws_subnet.admin_public_subnet.0.id}"
   vpc_security_group_ids = ["${aws_security_group.adm_bastion.id}", "${aws_security_group.vpc_sg.id}", "${aws_security_group.mgmt_sg.id}"]
@@ -45,7 +45,7 @@ resource "aws_instance" "bastion" {
 
 /* jenkins instance */
 resource "aws_instance" "jenkins" {
-  ami = "${lookup(var.aws_ubuntu_amis, format(\"%s-%s-%s-%s-%s\", var.region, var.ubuntu_distribution, var.ubuntu_architecture, var.ubuntu_virttype, var.ubuntu_storagetype))}"
+  ami = "${lookup(var.aws_ubuntu_amis, format("%s-%s-%s-%s-%s", var.region, var.ubuntu_distribution, var.ubuntu_architecture, var.ubuntu_virttype, var.ubuntu_storagetype))}"
   instance_type = "${var.jenkins_instance_type}"
   subnet_id = "${aws_subnet.admin_public_subnet.0.id}"
   vpc_security_group_ids = ["${aws_security_group.infra_jenkins.id}", "${aws_security_group.vpc_sg.id}", "${aws_security_group.mgmt_sg.id}"]
@@ -92,7 +92,7 @@ resource "aws_instance" "jenkins" {
 
 /* Spinnaker instance */
 resource "aws_instance" "spinnaker" {
-  ami = "${lookup(var.aws_spinnaker_amis, format(\"%s-%s\", var.region, var.ubuntu_virttype))}"
+  ami = "${lookup(var.aws_spinnaker_amis, format("%s-%s", var.region, var.ubuntu_virttype))}"
   instance_type = "${var.spinnaker_instance_type}"
   subnet_id = "${aws_subnet.admin_public_subnet.1.id}"
   vpc_security_group_ids = ["${aws_security_group.infra_spinnaker.id}", "${aws_security_group.vpc_sg.id}", "${aws_security_group.mgmt_sg.id}"]

--- a/aws/output.tf
+++ b/aws/output.tf
@@ -1,5 +1,5 @@
 
-resource "template_file" "output" {
+data "template_file" "output" {
 	template = "output.tpl"
 
 	vars {
@@ -22,5 +22,5 @@ resource "template_file" "output" {
 }
 
 output "" {
-	value = "${template_file.output.rendered}"
+	value = "${data.template_file.output.rendered}"
 }


### PR DESCRIPTION
… now checks for terraform version > 0.8.2 and no longer supplies the '-backup' option to terraform plan. Double quotes now no longer need to be escaped in format (or other hil commands)